### PR TITLE
Add support for rewriting `core-js/fn` imports

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -40,9 +40,15 @@ describe('rewriteCoreJsRequest', () => {
     });
   });
 
-  describe('rewrite `core-js/library/fn/*`', () => {
+  describe('rewrite `core-js/library/fn/*` and `core-js/fn/*`', () => {
     it('should rewrite `core-js/library/*` import to `core-js-pure/features/*`', () => {
       expect(rewriteCoreJsRequest('core-js/library/fn/object/assign')).toBe(
+        'core-js-pure/features/object/assign'
+      );
+    });
+
+    it('should rewrite `core-js/fn/*` import to `core-js-pure/features/*`', () => {
+      expect(rewriteCoreJsRequest('core-js/fn/object/assign')).toBe(
         'core-js-pure/features/object/assign'
       );
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,8 +34,8 @@ export const rewriteCoreJsRequest = (originalRequest: string, lowerVersion = fal
     }
   }
 
-  if (/core-js\/library\/fn\/(.*)/.test(originalRequest)) {
-    const [,matchedPath] = originalRequest.match(/core-js\/library\/fn\/(.*)/);
+  if (/core-js(?:\/library)?\/fn\/(.*)/.test(originalRequest)) {
+    const [,matchedPath] = originalRequest.match(/core-js(?:\/library)?\/fn\/(.*)/);
 
     const path = rewriteRenamedModules(matchedPath);
 


### PR DESCRIPTION
This adds support for rewriting `core-js/fn/*` imports into `core-js-pure/features/*`, like the one found in [react-live](https://github.com/FormidableLabs/react-live/blob/05e0ad7ab8231a2c119a91240a2bcc67cf8c6d02/src/utils/transpile/transform.js#L2).