### PR TITLE
Allow using the plugin with babel-loader on node_modules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ export default function CoreJSUpgradeWebpackPlugin(options: Options) {
   const resolve = options.resolveFrom ? resolveFrom.bind(null, options.resolveFrom) : require.resolve;
   
   return new NormalModuleReplacementPlugin(/core-js/, resource => {
-    const originalRequest = resource.request as string;
+    const originalRequest = (resource.userRequest || resource.request) as string;
     if (originalRequest.startsWith('./') || originalRequest.startsWith('../')) {
       return;
     }


### PR DESCRIPTION
CreateReactApp typically has babel-loader to process all the dependencies from node_modules to ensure that don't have things like `let` or `const` and other unexpected es6+ features.

That config does not currently work the the plugin. The plugin tries to `require.resolve` resource string containing loader request path, eg `babel-loader?core-js/somefile.js`.

Let's use userRequest instead of request when available to solve this problem.