### PR TITLE
Try to resolve from the context of the original request

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ export const rewriteCoreJsRequest = (originalRequest: string, lowerVersion = fal
     const [,matchedVersion, matchedPath] = originalRequest.match(/core-js\/es(5|6|7)(.*)?/);
 
     const version = matchedVersion;
-    
+
     if (version === '5') {
       return null;
     }
@@ -85,7 +85,7 @@ export default function CoreJSUpgradeWebpackPlugin(options: Options) {
   options = Object.assign({}, defaultOptions, options || {});
 
   const resolvers = options.resolveFrom ? [].concat(options.resolveFrom).map(r => resolveFrom.bind(null, r)) : [];
-  
+
   return new NormalModuleReplacementPlugin(/core-js/, resource => {
     const originalRequest = (resource.userRequest || resource.request) as string;
     if (originalRequest.startsWith('./') || originalRequest.startsWith('../')) {
@@ -96,7 +96,7 @@ export default function CoreJSUpgradeWebpackPlugin(options: Options) {
     }
 
     try {
-      require.resolve(originalRequest);
+      require.resolve(originalRequest, { paths: [resource.context] });
     } catch (originalError) {
       let error = true;
 
@@ -109,7 +109,7 @@ export default function CoreJSUpgradeWebpackPlugin(options: Options) {
             error = false;
           } catch (e) {}
         }
-  
+
         // attempt to upgrade the path from core-js v2 to v3 from backup
         if (error) {
           try {
@@ -118,7 +118,7 @@ export default function CoreJSUpgradeWebpackPlugin(options: Options) {
             error = false;
           } catch (e) {}
         }
-  
+
         // attempt to downgrade the path from es7 to es6 from backup
         if (error) {
           try {


### PR DESCRIPTION
## What?
Use the context of the original request to try and validate some resource is available.

## Why?
When trying to prove we can resolve a file, it is good to do it from the
original context of the file which is how webpack will try to resolve
it.

### Some background:
In our company, we have a shared build tool which we install, said build tool contains a `webpack.config.js` file which will (hopefully) run this plugin.

One of the main reasons we have to use this plugin is to avoid installing core-js@3 in every app that consumes it. We need to redirect requests for `core-js` to the version installed alongside the build tool.

Our current `node_modules` looks something like this:

```
node_modules/
	core-js@2/ # Hoisted from other dependencies
	build-tool/
		webpack.config.js # It runs this plugin
		core-js@3/ # The one we will like to use
```

Using `require.resolve(originalRequest)` will resolve that request from the context of `build-tool` which does contain `core-js@3` and will work. But most of the request come from the code babel will inject in our app. Which means they will actually be required from the context of the main app hence trying to use `core-js@2`. Without the `{ paths: [] }` options, `require.resolve` will succeed while the actual webpack require will fail, this PR solves that issue.

Thanks :)